### PR TITLE
Pickle 5 patch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.1.1
+current_version = 4.1.1.2
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<releaselevel>[a-z]+)?

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 |build-status| |license| |wheel| |pyversion| |pyimp|
 
-:Version: 4.1.1.1 (latentcall)
+:Version: 4.1.1.2 (latentcall)
 :Web: http://celeryproject.org/
 :Download: https://pypi.python.org/pypi/celery/
 :Source: https://github.com/celery/celery/

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 
 SERIES = 'latentcall'
 
-__version__ = '4.1.1.1'
+__version__ = '4.1.1.2'
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'
 __homepage__ = 'http://celeryproject.org'

--- a/celery/__main__.py
+++ b/celery/__main__.py
@@ -10,10 +10,30 @@ __all__ = ['main']
 
 def main():
     """Entrypoint to the ``celery`` umbrella command."""
+    patch_pickle()
     if 'multi' not in sys.argv:
         maybe_patch_concurrency()
     from celery.bin.celery import main as _main
     _main()
+
+
+def patch_pickle():
+    """Patch pickle to support protocol 5
+
+    Celery uses pickle.HIGHEST_PROTOCOL in several places, which makes
+    it difficult to upgrade to a Python (3.8+) that supports protocol 5.
+    The upgrade itself is not the problem, but issues arise if an older
+    version of Python needs to read pickles created on Python 3.8+.
+
+    Remove after dropping support for Python 3.7.x
+    """
+    import pickle
+    if pickle.HIGHEST_PROTOCOL < 5:
+        try:
+            import pickle5
+            sys.modules["pickle"] = pickle5
+        except ImportError:
+            pass
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,4 +1,4 @@
-:Version: 4.1.1.1 (latentcall)
+:Version: 4.1.1.2 (latentcall)
 :Web: http://celeryproject.org/
 :Download: https://pypi.python.org/pypi/celery/
 :Source: https://github.com/celery/celery/


### PR DESCRIPTION
Celery uses `pickle.HIGHEST_PROTOCOL` in several places, which makes it difficult to upgrade to a Python (3.8+) that supports protocol 5. The upgrade itself is not the problem, but issues arise if an older version of Python needs to read pickles created on Python 3.8+.

:blowfish: Review by commit.